### PR TITLE
OT258-99: Abrir nueva vista al seleccionar item "Nosotros" en menú + home fragment fix

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/view/fragments/homeFragment/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/fragments/homeFragment/HomeFragment.kt
@@ -107,10 +107,12 @@ class HomeFragment : Fragment() {
     // Init the recyclerview with the query's response
     private fun initWelcomeRecyclerView(list: List<SlidesDataModel>) {
         //helper to snap cards in the center of the screen
-        val snapHelper = LinearSnapHelper()
         if (list.isNotEmpty()) {
             binding.rvWelcomeActivityView.adapter = WelcomeActivitiesAdapter(list)
-            snapHelper.attachToRecyclerView(binding.rvWelcomeActivityView)
+            if (binding.rvWelcomeActivityView.onFlingListener == null){
+                val snapHelper = LinearSnapHelper()
+                snapHelper.attachToRecyclerView(binding.rvWelcomeActivityView)
+            }
         }
     }
 

--- a/app/src/main/res/menu/bottom_main_navigation.xml
+++ b/app/src/main/res/menu/bottom_main_navigation.xml
@@ -3,7 +3,7 @@
 <!-- These are the main navigation items (buttons) of mainActivity -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/nav_Inicio"
+        android:id="@+id/homeFragment"
         android:title="Inicio"
         android:icon="@drawable/ic_main_nav_home"/>
 


### PR DESCRIPTION
Added navigation back to home and fixed a bug where redefining the snap helper would crash the app